### PR TITLE
Fix compile instructions for Tag0.cpp

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ std::cout << result.as<double, ConstexprHeap<double, 8>>(double_heap) << "\n";
 
 ### Compile Command
 ```bash
-g++ -std=c++17 main.cpp -o tagged_value
+g++ -std=c++17 Tag0.cpp -o tagged_value
 ```
 
 ## Running the Program


### PR DESCRIPTION
## Summary
- update README compile command to use `Tag0.cpp`

## Testing
- `g++ -std=c++17 Tag0.cpp -o tagged_value` *(fails: incomplete type `TagTraits<long int>` used in nested name specifier)*

------
https://chatgpt.com/codex/tasks/task_e_68404a92b1a483288c5c3415041b138b