### PR TITLE
Handle heap overflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This project implements a system for type-tagged values that can represent integ
 ### Heap
 - **ConstexprHeap** is used to manage storage for types like doubles that require indirection.
 - The heap simulates memory allocation at compile time, with overflow protection.
+- Allocation failures return `-1`; `TaggedValue::from` asserts in this case so issues are caught early.
 
 ## Features
 - **Type-Safe Access**: Accessing a value as the wrong type returns a default value (e.g., `-1` or `false`).
@@ -82,7 +83,7 @@ g++ -std=c++17 main.cpp -o tagged_value
 
 ## Notes
 - The code is designed for constexpr evaluation, but can run dynamically as well.
-- Overflow protection is in place for heaps, but error reporting is minimal.
+- Overflow protection is in place for heaps. When the heap is full, `allocate` returns `-1` and `TaggedValue::from` triggers an assertion.
 - Extendable by defining additional type policies and extending `TagTraits`.
 
 ## Future Improvements

--- a/Tag0.cpp
+++ b/Tag0.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <string>
 #include <type_traits>
+#include <cassert>
 
 // Base Tagging Traits (Primary Template)
 template <typename T> 
@@ -26,6 +27,10 @@ struct BoolPolicy {
     static constexpr int64_t tag_value(bool value) { return (value ? 1 : 0) | tag; }
     static constexpr bool untag_value(int64_t value) { return (value & ~0b111) != 0; }
 };
+
+template <> struct TagTraits<int64_t> : IntPolicy {};
+template <> struct TagTraits<double> : DoublePolicy {};
+template <> struct TagTraits<bool> : BoolPolicy {};
 
 struct TaggedValue {
     int64_t raw;
@@ -55,7 +60,12 @@ struct TaggedValue {
             return { TagTraits<int64_t>::tag_value(value) };
         }
         else if constexpr (std::is_same_v<T, double>) {
-            return { heap.allocate(value) };
+            auto ptr = heap.allocate(value);
+            if (ptr == -1) {
+                assert(false && "Heap allocation failed in TaggedValue::from");
+                return { -1 };
+            }
+            return { ptr };
         }
         else if constexpr (std::is_same_v<T, bool>) {
             return { TagTraits<bool>::tag_value(value) };
@@ -110,27 +120,32 @@ constexpr TaggedValue add(const TaggedValue& a, const TaggedValue& b, IntHeap& i
 }
 
 
-template <> struct TagTraits<int64_t> : IntPolicy {};
-template <> struct TagTraits<double> : DoublePolicy {};
-template <> struct TagTraits<bool> : BoolPolicy {};
-
-
-
 
 // Test Functionality
 constexpr auto test_tagging() {
     ConstexprHeap<int64_t, 8> int_heap;
     ConstexprHeap<double, 8> double_heap;
-        
-    auto result = add(
-        TaggedValue::from<int64_t>(10, int_heap), 
-        TaggedValue::from<double>(20.5, double_heap), 
-        int_heap, 
-        double_heap
-    );
+
+    auto a = TaggedValue::from<int64_t>(10, int_heap);
+    assert(a.raw != -1 && "Allocation failed for int64_t in test_tagging");
+
+    auto b = TaggedValue::from<double>(20.5, double_heap);
+    assert(b.raw != -1 && "Allocation failed for double in test_tagging");
+
+    auto result = add(a, b, int_heap, double_heap);
 
     return result.as<double, ConstexprHeap<double, 8>>(double_heap); // Should return 30.5
 }
+
+constexpr bool test_heap_overflow() {
+    ConstexprHeap<double, 1> heap;
+    auto first = heap.allocate(1.0);
+    auto ok_first = first != -1;
+    auto second = heap.allocate(2.0);
+    auto ok_second = second == -1;
+    return ok_first && ok_second;
+}
+static_assert(test_heap_overflow(), "Heap overflow test failed");
 
 constexpr double result = test_tagging();
 


### PR DESCRIPTION
## Summary
- assert when `heap.allocate()` fails inside `TaggedValue::from`
- check allocations in `test_tagging`
- add a compile-time overflow test
- document overflow behavior

## Testing
- `g++ -std=c++17 Tag0.cpp -o tag0`
- `./tag0`

------
https://chatgpt.com/codex/tasks/task_e_68404a9051b883288c4d819469752105