### PR TITLE
Add cassert include

### DIFF
--- a/Tag0.cpp
+++ b/Tag0.cpp
@@ -3,6 +3,7 @@
 
 #include <iostream>
 #include <type_traits>
+#include <cassert>
 
 
 // Base Tagging Traits (Primary Template)


### PR DESCRIPTION
## Summary
- add `<cassert>` header to Tag0.cpp to allow use of `assert`

## Testing
- `g++ -std=c++17 Tag0.cpp -o tagged_value`


------
https://chatgpt.com/codex/tasks/task_e_6841979832c08328b455a65197594a07