### PR TITLE
Simplify is_type

### DIFF
--- a/Tag0.cpp
+++ b/Tag0.cpp
@@ -3,6 +3,7 @@
 
 #include <iostream>
 #include <type_traits>
+#include <cassert>
 
 
 // Base Tagging Traits (Primary Template)
@@ -34,7 +35,7 @@ template <> struct TagTraits<bool> : BoolPolicy {};
 struct TaggedValue {
     int64_t raw;
 
-    template <typename T, typename Heap>
+    template <typename T>
     constexpr bool is_type() const {
         return (raw & 0b111) == TagTraits<T>::tag;
     }
@@ -42,13 +43,13 @@ struct TaggedValue {
     template <typename T, typename Heap>
     constexpr T as(const Heap& heap) const {
         if constexpr (std::is_same_v<T, int64_t>) {
-            return is_type<int64_t, Heap>() ? TagTraits<int64_t>::untag_value(raw) : -1;
+            return is_type<int64_t>() ? TagTraits<int64_t>::untag_value(raw) : -1;
         }
         else if constexpr (std::is_same_v<T, double>) {
-            return is_type<double, Heap>() ? heap.dereference(raw) : -1.0;
+            return is_type<double>() ? heap.dereference(raw) : -1.0;
         }
         else if constexpr (std::is_same_v<T, bool>) {
-            return is_type<bool, Heap>() ? TagTraits<bool>::untag_value(raw) : false;
+            return is_type<bool>() ? TagTraits<bool>::untag_value(raw) : false;
         }
         return -1; // Unsupported type
     }
@@ -101,17 +102,17 @@ template <typename T, size_t N> struct ConstexprHeap {
 // Generalized Addition
 template <typename IntHeap, typename DoubleHeap>
 constexpr TaggedValue add(const TaggedValue& a, const TaggedValue& b, IntHeap& int_heap, DoubleHeap& double_heap) {
-    if (a.is_type<int64_t, IntHeap>() && b.is_type<int64_t, IntHeap>()) {
+    if (a.is_type<int64_t>() && b.is_type<int64_t>()) {
         return TaggedValue::from<int64_t>(
             a.as<int64_t, IntHeap>(int_heap) + b.as<int64_t, IntHeap>(int_heap),
             int_heap
         );
     }
 
-    double fa = a.is_type<int64_t, IntHeap>()
+    double fa = a.is_type<int64_t>()
         ? static_cast<double>(a.as<int64_t, IntHeap>(int_heap))
         : a.as<double, DoubleHeap>(double_heap);
-    double fb = b.is_type<int64_t, IntHeap>()
+    double fb = b.is_type<int64_t>()
         ? static_cast<double>(b.as<int64_t, IntHeap>(int_heap))
         : b.as<double, DoubleHeap>(double_heap);
 


### PR DESCRIPTION
## Summary
- simplify `TaggedValue::is_type` to take only one type parameter
- drop unused template parameter at call sites
- ensure code compiles by adding `<cassert>` include

## Testing
- `g++ -std=c++17 Tag0.cpp -o tagged_value && ./tagged_value`

------
https://chatgpt.com/codex/tasks/task_e_684197968d188328afd55729b6955b20