### PR TITLE
Fix missing include

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,11 @@ std::cout << result.as<double, ConstexprHeap<double, 8>>(double_heap) << "\n";
 ## Compilation
 ### Requirements
 - C++17 or later
+- `<cassert>` for assertions (already included in `Tag0.cpp`)
 
 ### Compile Command
 ```bash
-g++ -std=c++17 Tag0.cpp -o tagged_value
+g++ -std=c++17 -Wall -Wextra Tag0.cpp -o tagged_value
 ```
 
 ## Running the Program

--- a/Tag0.cpp
+++ b/Tag0.cpp
@@ -1,5 +1,6 @@
 #include <array>
 #include <cstdint>
+#include <cassert>
 
 #include <iostream>
 #include <type_traits>


### PR DESCRIPTION
## Summary
- include `<cassert>` for `assert`
- document updated compile command with warnings

## Testing
- `g++ -std=c++17 -Wall -Wextra Tag0.cpp -o tagged_value`
- `./tagged_value`

------
https://chatgpt.com/codex/tasks/task_e_68419795c10883288b104a1b03997176